### PR TITLE
Add dark mode toggle to Tkinter GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ python gui/launcher.py
 The GUI lets you choose a model, enter prompts and run either
 `generate_video.py` or `generate_video_df.py` without using the command line.
 You can also set a custom save location using the **Output Dir** field.
+A **Dark Mode** toggle is available to switch the interface to darker colors.
 
 #### Model Download
 You can download our models from Hugging Face:

--- a/gui/launcher.py
+++ b/gui/launcher.py
@@ -82,6 +82,32 @@ def browse_output(var):
         var.set(path)
 
 
+def apply_theme(root, dark: bool):
+    """Apply light or dark theme to Tkinter widgets."""
+    style = ttk.Style(root)
+    if dark:
+        style.theme_use('clam')
+        bg = '#333333'
+        fg = '#ffffff'
+        root.configure(background=bg)
+        style.configure('.', background=bg, foreground=fg)
+        style.configure('TEntry', fieldbackground=bg)
+        style.configure('TCombobox', fieldbackground=bg)
+        # Text widgets need explicit config
+        for widget in root.winfo_children():
+            if isinstance(widget, (tk.Entry, tk.Text, scrolledtext.ScrolledText)):
+                widget.configure(background=bg, foreground=fg, insertbackground=fg)
+    else:
+        style.theme_use('default')
+        root.configure(background='SystemButtonFace')
+        style.configure('.', background='SystemButtonFace', foreground='SystemButtonText')
+        style.configure('TEntry', fieldbackground='white')
+        style.configure('TCombobox', fieldbackground='white')
+        for widget in root.winfo_children():
+            if isinstance(widget, (tk.Entry, tk.Text, scrolledtext.ScrolledText)):
+                widget.configure(background='white', foreground='black', insertbackground='black')
+
+
 def main():
     root = tk.Tk()
     root.title('SkyReels Launcher')
@@ -93,9 +119,11 @@ def main():
     frames_var = tk.StringVar(value='97')
     guidance_var = tk.StringVar(value='6.0')
     outdir_var = tk.StringVar(value='video_out')
+    dark_var = tk.BooleanVar(value=False)
 
     ttk.Label(root, text='Script').grid(row=0, column=0, sticky='w')
     ttk.Combobox(root, textvariable=script_var, values=list(SCRIPTS.keys()), width=30).grid(row=0, column=1, sticky='ew')
+    ttk.Checkbutton(root, text='Dark Mode', variable=dark_var, command=lambda: apply_theme(root, dark_var.get())).grid(row=0, column=2, sticky='w')
 
     ttk.Label(root, text='Model').grid(row=1, column=0, sticky='w')
     ttk.Combobox(root, textvariable=model_var, values=MODEL_OPTIONS, width=60).grid(row=1, column=1, sticky='ew')
@@ -130,6 +158,7 @@ def main():
     ttk.Button(root, text='Run', command=lambda: run_generation(script_var, model_var, prompt_widget, image_var, res_var, frames_var, guidance_var, outdir_var, output)).grid(row=8, column=1, pady=5)
     ttk.Button(root, text='Quit', command=root.destroy).grid(row=8, column=2, pady=5)
 
+    apply_theme(root, dark_var.get())
     root.mainloop()
 
 


### PR DESCRIPTION
## Summary
- implement `apply_theme` to switch Tkinter colours
- add `Dark Mode` checkbutton in the launcher
- initialise theme when GUI starts
- document the dark mode option in README

## Testing
- `python -m py_compile gui/launcher.py`

------
https://chatgpt.com/codex/tasks/task_e_6877baeb6a2483259e634b18d3e80e1e