### PR TITLE
Fix dark mode styling bug

### DIFF
--- a/gui/launcher.py
+++ b/gui/launcher.py
@@ -83,6 +83,7 @@ def browse_output(var):
 
 
 def apply_theme(root, is_dark):
+    style = ttk.Style(root)
     if is_dark:
         bg_color = '#333333'  # Dark gray
         fg_color = '#ffffff'  # White


### PR DESCRIPTION
## Summary
- ensure `Style` instance exists in `apply_theme`

## Testing
- `python -m py_compile gui/launcher.py`
- `python gui/launcher.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_687802e8781c8325ab7b0e6236674007