### PR TITLE
Modify launcher button defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,15 @@ The demos above showcase 30-second videos generated using our SkyReels-V2 Diffus
 # clone the repository.
 git clone https://github.com/JuanTaco4You/SkyReels-V2
 cd SkyReels-V2
-# Install dependencies. Test environment uses Python 3.10.12.
+# Install dependencies if they are not already available. Test environment uses Python 3.10.12.
 pip install -r requirements.txt
 ```
 
+If the required packages are already installed, you can skip the step above.
+
 #### GUI Launcher
-After installing the dependencies you can launch a lightweight Tkinter
-interface for video generation:
+Once the required dependencies are installed (or if they were already present),
+you can launch a lightweight Tkinter interface for video generation:
 
 ```shell
 python3 gui/launcher.py

--- a/gui/launcher.py
+++ b/gui/launcher.py
@@ -493,6 +493,17 @@ def main():
     output = scrolledtext.ScrolledText(root, width=80, height=20)
     output.grid(row=12, column=0, columnspan=4, pady=5)
 
+    # Determine if required packages are already installed so the buttons can be
+    # enabled on launch without forcing the user to click "Install Dependencies"
+    try:
+        import diffusers  # noqa: F401
+        import decord  # noqa: F401
+        packages_installed = True
+    except Exception:
+        packages_installed = False
+
+    button_state = "normal" if packages_installed else "disabled"
+
     run_button = ttk.Button(
         root,
         text="Run",
@@ -524,7 +535,7 @@ def main():
             causal_block_size_var,
             output,
         ),
-        state="disabled",
+        state=button_state,
     )
     run_button.grid(row=11, column=1, pady=5)
 
@@ -532,7 +543,7 @@ def main():
         root,
         text="Prompt Enhancer",
         command=lambda: open_prompt_enhancer(prompt_widget),
-        state="disabled",
+        state=button_state,
     )
     enhancer_button.grid(row=11, column=2, pady=5)
 
@@ -540,7 +551,7 @@ def main():
         root,
         text="Captioner",
         command=open_captioner,
-        state="disabled",
+        state=button_state,
     )
     caption_button.grid(row=11, column=3, pady=5)
 


### PR DESCRIPTION
## Summary
- enable Run, Prompt Enhancer and Captioner buttons when deps are already installed
- keep install button for convenience
- clarify README that installing requirements is optional if packages exist

## Testing
- `python -m py_compile gui/launcher.py`

------
https://chatgpt.com/codex/tasks/task_e_687d1775a844832586c38077783df1af